### PR TITLE
Regions virtualisation listens to zoom

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -592,8 +592,11 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
       if (!this.wavesurfer) return
       renderIfVisible()
 
-      const unsubscribe = this.wavesurfer.on('scroll', renderIfVisible)
-      this.subscriptions.push(region.once('remove', unsubscribe), unsubscribe)
+      const unsubscribeScroll = this.wavesurfer.on('scroll', renderIfVisible)
+      const unsubscribeZoom = this.wavesurfer.on('zoom', renderIfVisible)
+
+      this.subscriptions.push(region.once('remove', unsubscribeScroll), unsubscribeScroll)
+      this.subscriptions.push(region.once('remove', unsubscribeZoom), unsubscribeZoom)
     }, 0)
   }
 


### PR DESCRIPTION
## Short description
Region virtualisation was not listening to zoom. This would mean that if a region was not visible at the start, and user zoomed out (without scrolling) so that the region was now in view, the region would not be rendered. 

## Implementation details


## How to test it


## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
